### PR TITLE
Fix user name punctuation

### DIFF
--- a/constants/API/ContextBuilder.ts
+++ b/constants/API/ContextBuilder.ts
@@ -100,7 +100,7 @@ export const buildTextCompletionContext = (max_length: number) => {
         const timestamp_string = `[${swipe_data.send_date.toString().split(' ')[0]} ${swipe_data.send_date.toLocaleTimeString()}]\n`
         const timestamp_length = currentInstruct.timestamp ? tokenizer(timestamp_string) : 0
 
-        const name_string = `${message.name} :`
+        const name_string = `${message.name}: `
         const name_length = currentInstruct.names ? tokenizer(name_string) : 0
 
         const shard_length = swipe_len + instruct_len + name_length + timestamp_length + wrap_length


### PR DESCRIPTION
User names are formatted not quite right, which breaks some models, especially small ones.

Before fix:
```
User :Hello
AI :How can I help?
```

After fix:
```
User: Hello
AI: How can I help?
```