### PR TITLE
fix: use JSON file extension for exported stories

### DIFF
--- a/app/components/ChatMenu/ChatEditPopup.tsx
+++ b/app/components/ChatMenu/ChatEditPopup.tsx
@@ -76,7 +76,7 @@ const ChatEditPopup: React.FC<ChatEditPopupProps> = ({ item, setNowLoading, nowL
     }
 
     const handleExportChat = async (menuRef: MenuRef) => {
-        const name = `Chatlogs-${charName}-${item.id}.txt`.replaceAll(' ', '_')
+        const name = `Chatlogs-${charName}-${item.id}.json`.replaceAll(' ', '_')
         await saveStringToDownload(JSON.stringify(await Chats.db.query.chat(item.id)), name, 'utf8')
         menuRef.current?.close()
         Logger.log(`File: ${name} saved to downloads!`, true)


### PR DESCRIPTION
Files are exported using `JSON.stringify`, using the json extension seems adequate?

---

Side Note: I don't know what's your policy regarding contributions, if any.

Maybe add info to README.md or a new CONTRIBUTING.md about the process you expect people to follow? PR format for example, running tests, discussion channels, etc.

Hope it helps. 