### PR TITLE
fix: the api value item style

### DIFF
--- a/app/screens/APIManager/APIValueItem.tsx
+++ b/app/screens/APIManager/APIValueItem.tsx
@@ -49,7 +49,7 @@ const APIValueItem: React.FC<APIValueItemProps> = ({ item, index }) => {
                     setShowEditor(false)
                 }}
             />
-            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', flex: 1 }}>
                 <ThemedSwitch
                     value={item.active}
                     onChangeValue={(value) => {
@@ -57,7 +57,7 @@ const APIValueItem: React.FC<APIValueItemProps> = ({ item, index }) => {
                     }}
                 />
 
-                <View style={{ marginLeft: spacing.xl }}>
+                <View style={{ marginLeft: spacing.xl, flexShrink: 1 }}>
                     <Text style={item.active ? styles.name : styles.nameInactive}>
                         {item.friendlyName}
                     </Text>
@@ -66,7 +66,7 @@ const APIValueItem: React.FC<APIValueItemProps> = ({ item, index }) => {
                     </Text>
                 </View>
             </View>
-            <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <View style={{ flexDirection: 'row', alignItems: 'center', flexShrink: 0 }}>
                 <ThemedButton
                     onPress={handleDelete}
                     variant="critical"


### PR DESCRIPTION
When the text of the friendlyName in the API value item is too long, the edit and delete buttons will be squeezed.
before the fix
![beforeFix](https://github.com/user-attachments/assets/953868c1-df6c-4c94-b456-41b1667677d1)
after the fix
![afterFix](https://github.com/user-attachments/assets/485326a2-facd-442f-bc67-5f99d5f3c2f7)
