### PR TITLE
provide default name when rename chat

### DIFF
--- a/app/screens/ChatMenu/ChatEditPopup.tsx
+++ b/app/screens/ChatMenu/ChatEditPopup.tsx
@@ -93,6 +93,7 @@ const ChatEditPopup: React.FC<ChatEditPopupProps> = ({ item, setNowLoading, nowL
                     await Chats.db.mutate.renameChat(item.id, text)
                 }}
                 textCheck={(text) => text.length === 0}
+                defaultValue = {item.name}
             />
             <PopupMenu
                 icon="edit"


### PR DESCRIPTION
use the origin chat name as default name when rename chat, I just think this may aligns better with user habits
![rename](https://github.com/user-attachments/assets/9c651dae-18ce-4ea1-b6b6-6ddb749ec776)
