### PR TITLE
Add fixes for Anthropic's unique request structure

### DIFF
--- a/app/screens/APIManager/AddAPI.tsx
+++ b/app/screens/APIManager/AddAPI.tsx
@@ -3,6 +3,7 @@ import ThemedButton from '@components/buttons/ThemedButton'
 import DropdownSheet from '@components/input/DropdownSheet'
 import MultiDropdownSheet from '@components/input/MultiDropdownSheet'
 import ThemedTextInput from '@components/input/ThemedTextInput'
+import { CLAUDE_VERSION } from '@lib/constants/GlobalValues'
 import { APIManagerValue, APIState } from '@lib/engine/API/APIManagerState'
 import { Logger } from '@lib/state/Logger'
 import { Theme } from '@lib/theme/ThemeManager'
@@ -33,10 +34,8 @@ const AddAPI = () => {
         const auth: any = {}
         if (template.features.useKey) {
             auth[template.request.authHeader] = template.request.authPrefix + values.key
-
-            // All authenticated Anthropic API calls require an `anthropic-version` header
             if (template.name === 'Claude') {
-                auth['anthropic-version'] = '2023-06-01'
+                auth['anthropic-version'] = CLAUDE_VERSION
             }
         }
         const result = await fetch(values.modelEndpoint, { headers: { ...auth } })

--- a/app/screens/APIManager/AddAPI.tsx
+++ b/app/screens/APIManager/AddAPI.tsx
@@ -4,7 +4,6 @@ import DropdownSheet from '@components/input/DropdownSheet'
 import MultiDropdownSheet from '@components/input/MultiDropdownSheet'
 import ThemedTextInput from '@components/input/ThemedTextInput'
 import { APIManagerValue, APIState } from '@lib/engine/API/APIManagerState'
-import claudeModels from '@lib/engine/API/ClaudeModels.json'
 import { Logger } from '@lib/state/Logger'
 import { Theme } from '@lib/theme/ThemeManager'
 import { Stack, useRouter } from 'expo-router'
@@ -30,13 +29,15 @@ const AddAPI = () => {
 
     const handleGetModelList = async () => {
         if (!template.features.useModel) return
-        if (template.defaultValues.modelEndpoint === '{{CLAUDE}}') {
-            setModelList(claudeModels.models)
-            return
-        }
-        let auth: any = {}
+
+        const auth: any = {}
         if (template.features.useKey) {
-            auth = { [template.request.authHeader]: template.request.authPrefix + values.key }
+            auth[template.request.authHeader] = template.request.authPrefix + values.key
+
+            // All authenticated Anthropic API calls require an `anthropic-version` header
+            if (template.name === 'Claude') {
+                auth['anthropic-version'] = '2023-06-01'
+            }
         }
         const result = await fetch(values.modelEndpoint, { headers: { ...auth } })
         const data = await result.json()

--- a/app/screens/APIManager/EditAPIModal.tsx
+++ b/app/screens/APIManager/EditAPIModal.tsx
@@ -4,6 +4,7 @@ import DropdownSheet from '@components/input/DropdownSheet'
 import MultiDropdownSheet from '@components/input/MultiDropdownSheet'
 import ThemedTextInput from '@components/input/ThemedTextInput'
 import FadeBackrop from '@components/views/FadeBackdrop'
+import { CLAUDE_VERSION } from '@lib/constants/GlobalValues'
 import { APIConfiguration } from '@lib/engine/API/APIBuilder.types'
 import { APIManagerValue, APIState } from '@lib/engine/API/APIManagerState'
 import { Logger } from '@lib/state/Logger'
@@ -53,10 +54,8 @@ const EditAPIModal: React.FC<EditAPIModalProps> = ({ index, show, close, origina
         const auth: any = {}
         if (template.features.useKey) {
             auth[template.request.authHeader] = template.request.authPrefix + values.key
-
-            // All authenticated Anthropic API calls require an `anthropic-version` header
             if (template.name === 'Claude') {
-                auth['anthropic-version'] = '2023-06-01'
+                auth['anthropic-version'] = CLAUDE_VERSION
             }
         }
         const result = await fetch(values.modelEndpoint, { headers: { ...auth } })

--- a/app/screens/APIManager/EditAPIModal.tsx
+++ b/app/screens/APIManager/EditAPIModal.tsx
@@ -6,7 +6,6 @@ import ThemedTextInput from '@components/input/ThemedTextInput'
 import FadeBackrop from '@components/views/FadeBackdrop'
 import { APIConfiguration } from '@lib/engine/API/APIBuilder.types'
 import { APIManagerValue, APIState } from '@lib/engine/API/APIManagerState'
-import claudeModels from '@lib/engine/API/ClaudeModels.json'
 import { Logger } from '@lib/state/Logger'
 import { Theme } from '@lib/theme/ThemeManager'
 import { useEffect, useState } from 'react'
@@ -51,13 +50,14 @@ const EditAPIModal: React.FC<EditAPIModalProps> = ({ index, show, close, origina
 
     const handleGetModelList = async () => {
         if (!template.features.useModel || !show) return
-        if (template.defaultValues.modelEndpoint === '{{CLAUDE}}') {
-            setModelList(claudeModels.models)
-            return
-        }
-        let auth: any = {}
+        const auth: any = {}
         if (template.features.useKey) {
-            auth = { [template.request.authHeader]: template.request.authPrefix + values.key }
+            auth[template.request.authHeader] = template.request.authPrefix + values.key
+
+            // All authenticated Anthropic API calls require an `anthropic-version` header
+            if (template.name === 'Claude') {
+                auth['anthropic-version'] = '2023-06-01'
+            }
         }
         const result = await fetch(values.modelEndpoint, { headers: { ...auth } })
         const data = await result.json()

--- a/lib/constants/GlobalValues.ts
+++ b/lib/constants/GlobalValues.ts
@@ -168,3 +168,5 @@ export const AppSettingsDefault: Record<AppSettings, boolean> = {
     [AppSettings.UseModelTemplate]: true,
     [AppSettings.ShowTokenPerSecond]: true,
 }
+
+export const CLAUDE_VERSION = '2023-06-01'

--- a/lib/engine/API/APIBuilder.ts
+++ b/lib/engine/API/APIBuilder.ts
@@ -1,3 +1,4 @@
+import { CLAUDE_VERSION } from '@lib/constants/GlobalValues'
 import { SSEFetch } from '@lib/engine/SSEFetch'
 import { Characters } from '@lib/state/Characters'
 import { Chats, useInference } from '@lib/state/Chat'
@@ -49,7 +50,7 @@ export const buildAndSendRequest = async () => {
     let header: any = {}
     if (config.features.useKey) {
         const anthropicVersion =
-            config.name === 'Claude' ? { 'anthropic-version': '2023-06-01' } : {}
+            config.name === 'Claude' ? { 'anthropic-version': CLAUDE_VERSION } : {}
 
         header = {
             ...anthropicVersion,

--- a/lib/engine/API/ClaudeModels.json
+++ b/lib/engine/API/ClaudeModels.json
@@ -1,7 +1,0 @@
-{
-    "models": [
-        { "name": "claude-3-5-sonnet-latest" },
-        { "name": "claude-3-5-haiku-latest" },
-        { "name": "claude-3-opus-latest" }
-    ]
-}

--- a/lib/engine/API/ContextBuilder.ts
+++ b/lib/engine/API/ContextBuilder.ts
@@ -255,7 +255,13 @@ export const buildChatCompletionContext = (
         index--
     }
 
-    if (config.features.useFirstMessage)
+    if (
+        config.features.useFirstMessage &&
+        // It might make sense to either make a firstMessage mandatory if useFirstMessage is enabled
+        // or else remove blank firstMessages for all payload types, but I don't know how other
+        // models expect this to behave, so this only affects Claude
+        (config.payload.type !== 'claude' || !!values.firstMessage)
+    )
         messageBuffer.push({
             role: completionFeats.userRole,
             [completionFeats.contentName]: values.firstMessage,

--- a/lib/engine/API/ContextBuilder.ts
+++ b/lib/engine/API/ContextBuilder.ts
@@ -244,6 +244,7 @@ export const buildChatCompletionContext = (
         const prefill = index === messages.length - 1 ? values.prefill : ''
 
         if (!swipe_data.swipe && !prefill && index === messages.length - 1) {
+            index--
             continue
         }
 
@@ -254,14 +255,7 @@ export const buildChatCompletionContext = (
         total_length += len
         index--
     }
-
-    if (
-        config.features.useFirstMessage &&
-        // It might make sense to either make a firstMessage mandatory if useFirstMessage is enabled
-        // or else remove blank firstMessages for all payload types, but I don't know how other
-        // models expect this to behave, so this only affects Claude
-        (config.payload.type !== 'claude' || !!values.firstMessage)
-    )
+    if (config.features.useFirstMessage && values.firstMessage)
         messageBuffer.push({
             role: completionFeats.userRole,
             [completionFeats.contentName]: values.firstMessage,

--- a/lib/engine/API/DefaultAPI.ts
+++ b/lib/engine/API/DefaultAPI.ts
@@ -292,7 +292,7 @@ export const defaultTemplates: APIConfiguration[] = [
 
         defaultValues: {
             endpoint: 'https://api.anthropic.com/v1/messages',
-            modelEndpoint: '{{CLAUDE}}',
+            modelEndpoint: 'https://api.anthropic.com/v1/models',
             prefill: '',
             firstMessage: '',
             key: '',
@@ -339,9 +339,9 @@ export const defaultTemplates: APIConfiguration[] = [
 
         model: {
             useModelContextLength: false,
-            nameParser: 'name',
+            nameParser: 'id',
             contextSizeParser: '',
-            modelListParser: 'models',
+            modelListParser: 'data',
         },
 
         ui: {

--- a/lib/engine/API/DefaultAPI.ts
+++ b/lib/engine/API/DefaultAPI.ts
@@ -303,7 +303,7 @@ export const defaultTemplates: APIConfiguration[] = [
             useKey: true,
             useModel: true,
             usePrefill: true,
-            useFirstMessage: true,
+            useFirstMessage: false,
             multipleModels: false,
         },
 

--- a/lib/engine/API/RequestBuilder.ts
+++ b/lib/engine/API/RequestBuilder.ts
@@ -92,20 +92,14 @@ const claudeRequest = (config: APIConfiguration, values: APIValues) => {
     const promptObject = prompt?.[config.request.promptKey]
     const finalPrompt = Array.isArray(promptObject)
         ? {
-              // Items with blank content typically only happen if the generation has failed
-              // However, if they stay in the array, Anthropic will reject all subsequent calls.
-              // An alternative would be to remove the blank message from the context during onError
-              // processing, but that code is shared, so for a Claude-only fix, this does the job
               [config.request.promptKey]: promptObject.filter(
-                  (item) => item.role !== systemRole && !!item['content']
+                  (item) => item.role !== systemRole && item['content']
               ),
           }
         : prompt
     return {
         system: systemPrompt,
         ...payloadFields,
-        // If `stream` is false, Claude does not use SSEs. Same format, just as
-        // a HTTP Response Body, not an Event, and there is no handler for that
         stream: true,
         ...model,
         ...stop,


### PR DESCRIPTION
Fixes for Anthropic formats as discussed in #231 

Also enables reading Anthropic models from the `models` endpoint instead of a static list