### PR TITLE
add CJK sentence endings to TTS regex.

### DIFF
--- a/lib/state/TTS.ts
+++ b/lib/state/TTS.ts
@@ -39,7 +39,8 @@ type TTSState = {
     insertBuffer: (text: string) => void
 }
 
-const sentenceEndRegex = /(?<=[^\d])([.?!])(?:["'`*_)]*)\s+(?=[A-Z0-9])|([.?!])(?:["'`*_)]*)$/gm
+const sentenceEndRegex =
+    /(?<=[^\d])([。…？！.?!])(?:["'`*_)]*)\s+(?=[A-Z0-9])|([。…？！.?!])(?:["'`*_)]*)$/gm
 
 export const useTTS = () => {
     const {
@@ -127,7 +128,7 @@ export const useTTSState = create<TTSState>()(
                     return
                 }
                 if (await Speech.isSpeakingAsync()) await Speech.stop()
-                const filter = /([!?.,*"])/
+                const filter = /([。…！？、!?.,*"])/
                 const filteredchunks: string[] = []
                 const chunks = text.split(filter)
                 chunks.forEach((item, index) => {


### PR DESCRIPTION
currently, the tts only triggers when latin sentence endings are reached.

this PR aims to bring chinese, japanese and korean sentence endings as well, so the tts triggers when it reaches the following characters
- 。
- …
- ？
- ！
which is the puntuation counterpart for at least these three countries, and languages using similar writing systems.

i might be forgetting some, if so, please tell me.

i tested my changes, they work, but since i do not fully understand the code around the regex, i might have accidentally broken something.
I think it is unlikely, but i feel like it's worth pointing it out, in case a tts-related issue comes up.