### PR TITLE
feat: add LiteLLM as built-in API provider

### DIFF
--- a/lib/engine/API/DefaultAPI.ts
+++ b/lib/engine/API/DefaultAPI.ts
@@ -635,6 +635,78 @@ export const defaultTemplates: APIConfiguration[] = [
             selectableModel: true,
         },
     },
+    // LiteLLM
+    {
+        version: 1,
+        name: 'LiteLLM',
+
+        defaultValues: {
+            endpoint: 'http://localhost:4000/v1/chat/completions',
+            modelEndpoint: 'http://localhost:4000/v1/models',
+            prefill: '',
+            firstMessage: '',
+            key: '',
+            model: undefined,
+        },
+
+        features: {
+            usePrefill: false,
+            useFirstMessage: false,
+            useKey: true,
+            useModel: true,
+            multipleModels: false,
+        },
+
+        request: {
+            requestType: 'stream',
+            samplerFields: [
+                { externalName: 'max_context_length', samplerID: SamplerID.CONTEXT_LENGTH },
+                { externalName: 'max_tokens', samplerID: SamplerID.GENERATED_LENGTH },
+                { externalName: 'stream', samplerID: SamplerID.STREAMING },
+                { externalName: 'temperature', samplerID: SamplerID.TEMPERATURE },
+                { externalName: 'top_p', samplerID: SamplerID.TOP_P },
+                { externalName: 'presence_penalty', samplerID: SamplerID.PRESENCE_PENALTY },
+                { externalName: 'frequency_penalty', samplerID: SamplerID.FREQUENCY_PENALTY },
+                { externalName: 'seed', samplerID: SamplerID.SEED },
+            ],
+            completionType: {
+                type: 'chatCompletions',
+                userRole: 'user',
+                systemRole: 'system',
+                assistantRole: 'assistant',
+                contentName: 'content',
+                supportsImages: true,
+            },
+            authHeader: 'Authorization',
+            authPrefix: 'Bearer ',
+            responseParsePattern: 'choices.0.delta.content',
+            reasoningParsePattern: [
+                'choices.0.delta.reasoning_content',
+                'choices.0.delta.reasoning',
+            ],
+            useStop: true,
+            stopKey: 'stop',
+            promptKey: 'messages',
+            removeLength: true,
+        },
+
+        payload: {
+            type: 'openai',
+        },
+
+        model: {
+            useModelContextLength: false,
+            nameParser: 'id',
+            contextSizeParser: '',
+            modelListParser: 'data',
+        },
+
+        ui: {
+            editableCompletionPath: true,
+            editableModelPath: true,
+            selectableModel: true,
+        },
+    },
     // Chat Completions
     {
         version: 1,


### PR DESCRIPTION


## Summary

Add [LiteLLM](https://github.com/BerriAI/litellm) as a built-in API provider template, giving users access to 100+ LLM providers (OpenAI, Anthropic, Azure, Vertex AI, Bedrock, OpenRouter, Groq, etc.) through a single OpenAI-compatible proxy.

## Changes

- `lib/engine/API/DefaultAPI.ts` - Add `LiteLLM` entry to `defaultTemplates` array (72 lines, single file)

The template uses:
- OpenAI Chat Completions format (`choices.0.delta.content` parse pattern)
- Reasoning content support (`choices.0.delta.reasoning_content` and `choices.0.delta.reasoning`)
- Editable completion and model URLs (so users can point at any proxy address)
- Standard OpenAI samplers (temperature, top_p, presence/frequency penalty, seed)
- `/v1/models` auto-discovery
- Image support

## Tests

E2E against a live LiteLLM proxy (Azure AI Foundry Anthropic backend):

**Model discovery (`GET /v1/models`):**
```
['claude-sonnet-4-6']
```

**Streaming chat completion (matches `choices.0.delta.content` parse pattern):**
```
data: {"id":"chatcmpl-...","model":"claude-sonnet-4-6","choices":[{"index":0,"delta":{"content":"OK","role":"assistant"}}]}
data: {"id":"chatcmpl-...","model":"claude-sonnet-4-6","choices":[{"finish_reason":"stop","index":0,"delta":{}}]}
data: [DONE]
```

**Non-streaming response:**
```
Response: OK
Model: claude-sonnet-4-6
PASS
```

## Example usage

1. Open ChatterUI > Connections Manager > Add Connection
2. Select "LiteLLM" template
3. Enter your LiteLLM proxy URL (default: `http://localhost:4000/v1/chat/completions`)
4. Enter your proxy API key (if auth is enabled)
5. Select a model from the auto-discovered list
6. Start chatting

## Notes

- Single file, purely additive. No existing templates modified.
- Template follows the exact same pattern as OpenRouter and Chat Completions templates.
- Works with any LiteLLM proxy deployment (local, Docker, cloud).
