### PR TITLE
increase max sampler context length to 262k

### DIFF
--- a/lib/constants/SamplerData.ts
+++ b/lib/constants/SamplerData.ts
@@ -118,7 +118,7 @@ export const Samplers = {
         values: {
             type: 'integer',
             min: 1024,
-            max: 128000,
+            max: 262144,
             default: 8192,
             step: 16,
             precision: 0,


### PR DESCRIPTION
I found the default 128k to be quite insufficient for using in the general case. Most moderate size LLMs now (Gemma4 / Qwen 3.6 / Mistral) support 256k as the largest window. 

Really this number should be `1000000` but doubling to 256k seems like the smallest appropriate change.